### PR TITLE
[develop_DTC] Add new forecast fields, vx metrics for deterministic forecasts, and METviewer database

### DIFF
--- a/DTC/metviewer_plotting/make_multi_mv_vx_plots.py
+++ b/DTC/metviewer_plotting/make_multi_mv_vx_plots.py
@@ -148,7 +148,9 @@ def make_multi_mv_vx_plots(args, valid_vals, vx_metric_needs_thresh):
     mv_database = plot_config_dict['mv_database']
     model_names_short = plot_config_dict['model_names_short']
     fcst_init_info = plot_config_dict['fcst_init_info']
+    vx_mask = plot_config_dict['vx_mask']
     fcst_len_hrs = plot_config_dict['fcst_len_hrs']
+    plot_CIs_all_metrics = plot_config_dict['plot_CIs_all_metrics']
     metrics_fields_levels_threshes_dict = plot_config_dict["metrics_fields_levels_threshes"]
 
     # Load the yaml-format METviewer database configuration file and extract
@@ -165,7 +167,7 @@ def make_multi_mv_vx_plots(args, valid_vals, vx_metric_needs_thresh):
     fcst_init_info = [str(elem) for elem in fcst_init_info.values()]
 
     # Convert fcst_len_hrs from an integer to a string since that's what
-    # the jinja2 templates exptect.
+    # the jinja2 templates expect.
     fcst_len_hrs = str(fcst_len_hrs)
 
     # Check if output directory exists and take action according to how the
@@ -961,11 +963,13 @@ def make_multi_mv_vx_plots(args, valid_vals, vx_metric_needs_thresh):
                                  '--output_dir', output_dir_crnt_vx_metric, \
                                  '--model_names_short', ] + model_names_short \
                               + ['--fcst_init_info'] + fcst_init_info \
-                              + ['--fcst_len_hrs', fcst_len_hrs, \
+                              + ['--fcst_len_hrs', fcst_len_hrs,
+                                 '--' + ('' if plot_CIs_all_metrics else 'no-') + 'plot_CIs',
                                  '--vx_metric', metric,
                                  '--fcst_field', field,
                                  '--fcst_level', level,
-                                 '--threshold', thresh]
+                                 '--threshold', thresh,
+                                 '--vx_mask', vx_mask]
 
                     msg = dedent(f"""
                         Argument list passed to plotting script is:
@@ -1049,7 +1053,16 @@ def main():
     None
     """
 
+    #
+    # Create ArgumentParser object.  Note that specifying 
+    #
+    #   formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    #
+    # in the arguments list causes the default values of arguments to be
+    # printed out when the help is invoked on the command line.
+    #
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description='Call METviewer to create vx plots.'
     )
 

--- a/DTC/metviewer_plotting/make_single_mv_vx_plot.py
+++ b/DTC/metviewer_plotting/make_single_mv_vx_plot.py
@@ -295,9 +295,11 @@ def get_valid_vx_plot_params(valid_vx_plot_params_config_fp):
     valid_vx_metrics = valid_vx_plot_params['valid_vx_metrics'].keys()
     vx_metric_long_names = {}
     vx_metric_needs_thresh = {}
+    vx_metric_CIs_allowed = {}
     for metric in valid_vx_metrics:
         vx_metric_long_names[metric] = valid_vx_plot_params['valid_vx_metrics'][metric]['long_name']
         vx_metric_needs_thresh[metric] = valid_vx_plot_params['valid_vx_metrics'][metric]['needs_thresh']
+        vx_metric_CIs_allowed[metric] = valid_vx_plot_params['valid_vx_metrics'][metric]['CIs_allowed']
 
     # Get list of valid forecast fields.
     valid_fcst_fields = valid_vx_plot_params['valid_fcst_fields'].keys()
@@ -377,6 +379,7 @@ def get_valid_vx_plot_params(valid_vx_plot_params_config_fp):
     valid_vx_plot_params['valid_units_by_fcst_field'] = valid_units_by_fcst_field
     valid_vx_plot_params['vx_metric_long_names'] = vx_metric_long_names
     valid_vx_plot_params['vx_metric_needs_thresh'] = vx_metric_needs_thresh
+    valid_vx_plot_params['vx_metric_CIs_allowed'] = vx_metric_CIs_allowed
     valid_vx_plot_params['avail_mv_colors_codes'] = avail_mv_colors_codes
     valid_vx_plot_params['choices'] = choices
 
@@ -440,7 +443,8 @@ def parse_args(argv, valid_vx_plot_params):
 
     parser.add_argument('--mv_host_config_fp',
                         type=str,
-                        required=False, default='mv_hosts.yaml',
+                        required=False,
+                        default='mv_hosts.yaml',
                         help='METviewer host configuration file.')
 
     parser.add_argument('--mv_database',
@@ -450,7 +454,8 @@ def parse_args(argv, valid_vx_plot_params):
 
     parser.add_argument('--mv_database_config_fp',
                         type=str,
-                        required=False, default='mv_databases.yaml',
+                        required=False,
+                        default='mv_databases.yaml',
                         help='METviewer database configuration file.')
 
     # Find the path to the directory containing the clone of the SRW App.
@@ -461,7 +466,8 @@ def parse_args(argv, valid_vx_plot_params):
     expts_dir = Path(os.path.join(home_dir, '../expts_dir')).resolve()
     parser.add_argument('--output_dir',
                         type=str,
-                        required=False, default=os.path.join(expts_dir, 'mv_output'),
+                        required=False,
+                        default=os.path.join(expts_dir, 'mv_output'),
                         help='Directory in which to place output (e.g. plots) from METviewer.')
 
     parser.add_argument('--model_names_short', nargs='+',
@@ -471,7 +477,8 @@ def parse_args(argv, valid_vx_plot_params):
 
     parser.add_argument('--model_colors', nargs='+',
                         type=str,
-                        required=False, default=choices['color'],
+                        required=False,
+                        default=choices['color'],
                         choices=choices['color'],
                         help='Color to use for each model appearing the vx plot.')
 
@@ -508,14 +515,35 @@ def parse_args(argv, valid_vx_plot_params):
 
     parser.add_argument('--threshold',
                         type=str,
-                        required=False, default='',
+                        required=False,
+                        default='',
                         help=dedent(f"""
                             Threshold for the specified forecast field for which to generate the vx
                             plot.  This option is ignored for metrics that do not require a threshold.
                             """))
 
+    parser.add_argument('--vx_mask',
+                        type=str,
+                        required=True,
+                        help='Name of geographic region to which to limit the verification.')
+
+    parser.add_argument('--plot_CIs',
+                        required=False,
+                        action=argparse.BooleanOptionalAction,
+                        default=True,
+                        help=dedent(f"""
+                            Flag for including confidence intervals (CIs) around each data point.
+                            Not all vx metrics allow for CIs; for those that don't, this is disabled
+                            regardless of the value on the command line.
+                            """))
+
+    # If argparse.SUPPRESS is specified as the default value for an argument
+    # and if that argument is not provided on the command line, it will not
+    # be present in the Namespace object returned by the parser. 
     parser.add_argument('--incl_ens_means',
-                        required=False, action=argparse.BooleanOptionalAction, default=argparse.SUPPRESS,
+                        required=False,
+                        action=argparse.BooleanOptionalAction,
+                        default=argparse.SUPPRESS,
                         help=dedent(f"""
                             Flag for including ensemble mean curves in plot.  This flag is only
                             relevant for the metrics 'bias' and 'fbias'.  It is ignored for other
@@ -569,6 +597,7 @@ def generate_metviewer_xml(cla, valid_vx_plot_params, mv_databases_dict):
     valid_units_by_fcst_field = valid_vx_plot_params['valid_units_by_fcst_field']
     vx_metric_long_names = valid_vx_plot_params['vx_metric_long_names']
     vx_metric_needs_thresh = valid_vx_plot_params['vx_metric_needs_thresh']
+    vx_metric_CIs_allowed = valid_vx_plot_params['vx_metric_CIs_allowed']
     avail_mv_colors_codes = valid_vx_plot_params['avail_mv_colors_codes']
 
     # Load the host configuration file into a dictionary and find in it the
@@ -613,7 +642,26 @@ def generate_metviewer_xml(cla, valid_vx_plot_params, mv_databases_dict):
     # Extract the METviewer database information.
     database_info = mv_databases_dict[cla.mv_database]
     valid_threshes_in_db = list(database_info['valid_threshes'])
+    fcst_is_ensemble = database_info['fcst_is_ensemble']
+    vx_masks_in_db = database_info['vx_masks']
     model_info = list(database_info['models'])
+
+    # Make sure the specified verification mask is a valid one, i.e. that it
+    # exists in the list of masks for this database.
+    if cla.vx_mask not in vx_masks_in_db:
+        msg = dedent(f"""
+            The verification mask specified on the command line (cla.vx_mask) does
+            not correspond to any of the masks (vx_masks_in_db) in the specified 
+            database (cla.mv_database; also see the database configuration file
+            cla.mv_database_config_fp):
+              cla.mv_database = {get_pprint_str(cla.mv_database)}
+              cla.mv_database_config_fp = {get_pprint_str(cla.mv_database_config_fp)}
+              vx_masks_in_db = {get_pprint_str(vx_masks_in_db)}
+              cla.vx_mask = {get_pprint_str(cla.vx_mask)}
+            Stopping.
+            """)
+        logging.error(msg)
+        raise ValueError(msg)
 
     # METviewer expects the model (long) names passed to it to be in alphabetic
     # order.  Thus, the list of model (short) names passed via the command
@@ -628,6 +676,46 @@ def generate_metviewer_xml(cla, valid_vx_plot_params, mv_databases_dict):
     model_names_avail_in_db = [model_info[i]['long_name'] for i in range(0,num_models_avail_in_db)]
     model_names_short_avail_in_db = [model_info[i]['short_name'] for i in range(0,num_models_avail_in_db)]
 
+    for model_dict in model_info:
+        if 'num_ens_mems' not in model_dict:
+            if fcst_is_ensemble:
+                msg = dedent(f"""
+                    The flag 'fcst_is_ensemble' is set to True for the specified METviewer database
+                    (mv_database), i.e. the database is specified to contain forecast(s) that are
+                    ensemble, but in the database configuration file (mv_database_config_fp), the
+                    number of ensemble members (num_ens_mems) is not defined for the current model
+                    (model_dict):
+                      cla.mv_database = {get_pprint_str(cla.mv_database)}
+                      cla.mv_database_config_fp = {get_pprint_str(cla.mv_database_config_fp)}
+                      {model_dict = }
+                    Stopping.
+                    """)
+                logging.error(msg)
+                raise ValueError(msg)
+            else:
+                model['num_ens_mems'] = 1
+
+        else:
+            num_ens_mems = model_dict['num_ens_mems']
+            if not fcst_is_ensemble and (num_ens_mems > 1):
+                msg = dedent(f"""
+                    The flag 'fcst_is_ensemble' is set to False for the specified METviewer database
+                    (mv_database), i.e. the database is specified to contain forecast(s) that are
+                    deterministic, but in the database configuration file (mv_database_config_fp),
+                    the number of ensemble members (num_ens_mems) for the current model (model_dict)
+                    has been set to a value greater than 1:
+                      cla.mv_database = {get_pprint_str(cla.mv_database)}
+                      cla.mv_database_config_fp = {get_pprint_str(cla.mv_database_config_fp)}
+                      database_info['fcst_is_ensemble'] = {database_info['fcst_is_ensemble']}
+                      {model_dict = }
+                      {database_info['fcst_is_ensemble'] = }
+                    For each model in the database, either set 'num_ens_mems' to 1 or leave it
+                    unspecified (in which case it will be defined and set to 1).
+                    Stopping.
+                    """)
+                logging.error(msg)
+                raise ValueError(msg)
+            
     # Make sure model names on the command line are not duplicated because
     # METviewer will throw an error in this case.  Create a set (using curly
     # braces) to store duplicate values.  Note that a set must be used here
@@ -800,13 +888,48 @@ def generate_metviewer_xml(cla, valid_vx_plot_params, mv_databases_dict):
         '\n'
     logging.debug(msg)
 
+    # If incl_ens_means is not specified on the command line...
     if ('incl_ens_means' not in cla):
-        incl_ens_means = False
-        if (cla.vx_metric == 'bias'): incl_ens_means = True
+        # If the forecast is deterministic, turn off plotting of ensemble means.
+        if not fcst_is_ensemble:
+            incl_ens_means = False
+        # If the forecast is ensemble, turn on plotting of ensemble means only
+        # for the vx metrics bias and fbias.
+        else:
+            incl_ens_means = False
+            if cla.vx_metric in ['bias', 'fbias']: incl_ens_means = True
+
+    # If incl_ens_means is specified on the command line...
     else:
         incl_ens_means = cla.incl_ens_means
-    # Apparently we can just reset or create incl_ens_means within the cla Namespace
-    # as follows:
+        # If incl_ens_means is set to True, it may have to be changed depending
+        # on the forecast type (deterministic or ensemble) and/or the metric to
+        # be plotted.
+        if incl_ens_means:
+            # If incl_ens_means is set to True on the command line but the forecast
+            # is deterministic, log an informational message and reset incl_ens_means
+            # to False. 
+            if not fcst_is_ensemble:
+                msg = dedent(f"""
+                    incl_ens_means has been set to True on the command line, but we are verifying
+                    a deterministic forecast.  Thus, resetting incl_ens_means to False.
+                    """)
+                logging.debug(msg)
+                incl_ens_means = False
+            # If incl_ens_means is set to True on the command line and the forecast
+            # is ensemble but the metric to be plotted is not bias or fbias, log an
+            # informational message and reset incl_ens_means to False. 
+            elif cla.vx_metric in ['bias', 'fbias']:
+                msg = dedent(f"""
+                    incl_ens_means has been set to True on the command line, but the verification
+                    metric to be plotted is not bias or fbias.  Thus, resetting incl_ens_means
+                    to False.
+                    """)
+                logging.debug(msg)
+                incl_ens_means = False
+
+    # Reset or create incl_ens_means within the cla Namespace to the value of incl_ens_means 
+    # set above.
     cla.incl_ens_means = incl_ens_means
 
     valid_fcst_levels = valid_fcst_levels_by_fcst_field[cla.fcst_field]
@@ -876,11 +999,13 @@ def generate_metviewer_xml(cla, valid_vx_plot_params, mv_databases_dict):
 
     # Form the plot title.
     level_str = ''.join([level_info['value'], level_info['units']])
+    vxmask_str = f'(vxmask = {cla.vx_mask})'
     plot_title = ' '.join(filter(None,
                           [vx_metric_long_names[cla.vx_metric], 'for',
                            level_str, 
                            fcst_field_long_names[cla.fcst_field],
-                           thresh_info['in_plot_title']]))
+                           thresh_info['in_plot_title'],
+                           vxmask_str]))
 
     # Form the job title needed in the xml.
     fcst_field_uc = cla.fcst_field.upper()
@@ -924,7 +1049,8 @@ def generate_metviewer_xml(cla, valid_vx_plot_params, mv_databases_dict):
     # The remaining plot (i.e. vx metric) types have forecast hour on the
     # x-axis.  For these, there are several aspects of the plotting to
     # consider for setting xtick_label_freq.
-    elif cla.vx_metric in ['auc', 'bias', 'brier', 'fbias', 'ss']:
+    elif cla.vx_metric in ['auc', 'bcrmse', 'bias', 'brier', 'fbar', 'fbar_obar',
+                           'fbias', 'gss', 'obar', 'rmse', 'ss']:
 
         # Create a list of the forecast hours at which the metric is available
         # (vx_metric_fcst_hrs).  This requires first determining the metric's
@@ -1011,10 +1137,14 @@ def generate_metviewer_xml(cla, valid_vx_plot_params, mv_databases_dict):
     # For the given forecast field, generate a name for the corresponding
     # observation type in the METviewer database.
     obs_type = ''
-    if cla.fcst_field == 'apcp' :
+    if cla.fcst_field == 'apcp':
         obs_type = 'CCPA'
-    elif cla.fcst_field in ['refc', 'retop'] :
+    elif cla.fcst_field in ['refc', 'retop']:
         obs_type = 'MRMS'
+    elif cla.fcst_field in ['aotk']:
+        obs_type = 'AERONET_AOD'
+    elif cla.fcst_field in ['pm25', 'pm10']:
+        obs_type = 'AIRNOW_HOURLY_AQOBS'
     # The level for CAPE is 'L0', which means the surface, but its obtype is ADPUPA
     # (upper air).  It's a bit unintuitive...
     elif cla.fcst_field == 'cape':
@@ -1034,6 +1164,28 @@ def generate_metviewer_xml(cla, valid_vx_plot_params, mv_databases_dict):
           obs_type = {get_pprint_str(obs_type)}
         """)
     logging.debug(msg)
+
+    # Set flag that determines whether or not confidence intervals (CIs)
+    # will be included in the plot.  We disable this if (for whatever 
+    # reason) CIs cannot be plotted for this metric.
+    plot_CIs = cla.plot_CIs
+    if not vx_metric_CIs_allowed[cla.vx_metric]:
+        plot_CIs = False
+        msg = dedent(f"""
+            Confidence intervals (CIs) cannot or should not be plotted for the current
+            metric (cla.metric), as specified in the dictionary "vx_metric_CIs_allowed".
+            Setting the flag for plotting CIs (plot_CIs) to False:
+              {cla.vx_metric = }
+              vx_metric_CIs_allowed['{cla.vx_metric}'] = {vx_metric_CIs_allowed[cla.vx_metric]}
+              {plot_CIs = }
+            """)
+        logging.debug(msg)
+
+    # Set some METviewer plotting parameters for the obs.
+    line_type_obs = "b"
+    line_width_obs = 1
+    color_obs = 'blue'
+    color_obs = avail_mv_colors_codes[color_obs]['hex_code']
 
     # Create dictionary containing values for the variables appearing in the
     # jinja2 template.
@@ -1056,18 +1208,24 @@ def generate_metviewer_xml(cla, valid_vx_plot_params, mv_databases_dict):
                    "vx_metric_uc": cla.vx_metric.upper(),
                    "vx_metric_lc": cla.vx_metric.lower(),
                    "vx_metric_mv": vx_metric_mv,
+                   "vx_mask": cla.vx_mask,
                    "num_fcst_inits": num_fcst_inits,
                    "fcst_init_times": fcst_init_times_YmDHMS,
                    "fcst_len_hrs": cla.fcst_len_hrs,
                    "job_title": job_title,
                    "plot_title": plot_title,
                    "caption": fcst_init_info_str,
+                   "fcst_is_ensemble": fcst_is_ensemble,
                    "incl_ens_means": incl_ens_means,
                    "num_series": num_series,
                    "order_series": order_series,
+                   "plot_CIs": plot_CIs,
                    "xtick_label_freq": xtick_label_freq,
                    "line_types": line_types,
-                   "line_widths": line_widths}
+                   "line_widths": line_widths,
+                   "line_type_obs": line_type_obs,
+                   "line_width_obs": line_width_obs,
+                   "color_obs": color_obs}
 
     # Empty strings are included in this concatenation to force insertion
     # of delimiter.
@@ -1081,8 +1239,8 @@ def generate_metviewer_xml(cla, valid_vx_plot_params, mv_databases_dict):
     template_fn = ''.join([cla.vx_metric, '.xml'])
     if (cla.vx_metric in ['auc', 'brier']):
         template_fn = 'auc_brier.xml'
-    elif (cla.vx_metric in ['bias', 'fbias']):
-        template_fn = 'bias_fbias.xml'
+    elif (cla.vx_metric in ['bcrmse', 'bias', 'fbar', 'fbar_obar', 'fbias', 'gss', 'obar', 'rmse']):
+        template_fn = 'bcrmse_bias_fbar_fbias_gss_obar_rmse.xml'
     elif (cla.vx_metric in ['rely', 'rhist']):
         template_fn = 'rely_rhist.xml'
     template_fp = os.path.join(templates_dir, template_fn)

--- a/DTC/metviewer_plotting/multi_plot_config.default.yaml
+++ b/DTC/metviewer_plotting/multi_plot_config.default.yaml
@@ -11,6 +11,14 @@ fcst_init_info:
 
 fcst_len_hrs: 36
 
+# The METplus verification mask to use.  Only locations inside this mask
+# are included when calculating metrics.
+vx_mask: 'CONUS'
+
+# Whether or not to (try to) plot confidence intervals.  This applies to all metrics
+# for which CIs are allowed (as specified in valid_vx_plot_params.yaml).
+plot_CIs_all_metrics: True
+
 metrics_fields_levels_threshes:
     #
     auc:

--- a/DTC/metviewer_plotting/multi_plot_config.mv_rrfsv1_science_eval.yaml
+++ b/DTC/metviewer_plotting/multi_plot_config.mv_rrfsv1_science_eval.yaml
@@ -1,0 +1,123 @@
+mv_host: 'mohawk'
+
+mv_database: 'mv_rrfsv1_science_eval'
+
+#model_names_short: ['href', 'gdas', 'gefs']
+#model_names_short: ['HRRR', 'NSSL-MPAS-HN', 'NSSL-MPAS-HT', 'NSSL-MPAS-RT', 'RRFS-A', 'GSL-MPAS-05']
+#model_names_short: ['GSL-MPAS-05-RT', 'HRRR', 'NSSL-MPAS-HN', 'NSSL-MPAS-HT', 'NSSL-MPAS-RT', 'RRFS-A']
+#model_names_short: ['GSL-MPAS-05-RT', 'HRRR', 'NSSL-MPAS-HN', 'NSSL-MPAS-HT', 'NSSL-MPAS-RT', 'RRFS-A']
+model_names_short: ['RRFS']
+
+fcst_init_info:
+    fcst_init_time_first: '2024010900'
+    num_fcst_inits: 31
+    fcst_init_intvl_hrs: 24
+
+fcst_len_hrs: 84
+
+# The METplus verification mask to use.  Only locations inside this mask
+# are included when calculating metrics.
+vx_mask: 'CONUS'
+
+# Whether or not to (try to) plot confidence intervals.  This applies to all metrics
+# for which CIs are allowed (as specified in valid_vx_plot_params.yaml).
+plot_CIs_all_metrics: True
+
+metrics_fields_levels_threshes:
+
+    fbar:
+        vis:
+            L0: []
+        AOTK:
+            L0: []
+    obar:
+        vis:
+            L0: []
+
+    bcrmse:
+        AOTK:
+            L0: []
+        dpt:
+            2m: []
+        pm25:
+            8m: []
+        pm10:
+            8m: []
+        tmp:
+            2m: []
+        vis:
+            L0: []
+        wind:
+            10m: []
+
+    bias:
+        AOTK:
+            L0: []
+        dpt:
+            2m: []
+        pm25:
+            8m: []
+        pm10:
+            8m: []
+        tmp:
+            2m: []
+            500mb: []
+            700mb: []
+            850mb: []
+        vis:
+            L0: []
+        wind:
+            10m: []
+            700mb: []
+            850mb: []
+
+    fbar_obar:
+        AOTK:
+            L0: []
+        dpt:
+            2m: []
+        pm25:
+            8m: []
+        pm10:
+            8m: []
+        tmp:
+            2m: []
+        vis:
+            L0: []
+        wind:
+            10m: []
+
+    rmse:
+        AOTK:
+            L0: []
+        dpt:
+            2m: []
+        pm25:
+            8m: []
+        pm10:
+            8m: []
+        tmp:
+            2m: []
+        vis:
+            L0: []
+        wind:
+            10m: []
+
+# These fail.  Need to understand why.
+#    fbias:
+#        apcp:
+##            03h: ['gt0.0mm', 'ge2.54mm']
+##            03h: ['ge6.350mm']
+##            03h: ['ge2.54mm', 'ge6.350mm']
+#            03h: ['ge2.54mm']
+#        refc:
+##            L0: ['ge20dBZ', 'ge30dBZ', 'ge40dBZ']
+#            L0: ['ge20dBZ']
+
+# These fail.  Need to understand why.
+#    gss:
+#        apcp:
+#            03h: ['ge2.54mm', 'ge6.350mm']
+#        refc:
+#            L0: ['ge20dBZ', 'ge30dBZ', 'ge40dBZ']
+

--- a/DTC/metviewer_plotting/mv_databases.yaml
+++ b/DTC/metviewer_plotting/mv_databases.yaml
@@ -6,13 +6,16 @@ generic_database: &generic_database
          'ge258K', 'ge263K', 'ge268K', 'ge278K', 'ge283K', 'ge288K', 'ge293K', 'ge298K', 'ge303K',
          'lt1609m', 'ge8045m', 'ge5400m', 'ge5880m',
          'ge5mps', 'ge10mps', 'ge15mps', 'ge21mps']
+    fcst_is_ensemble: False
+    vx_masks: ['CONUS']
     models:
         - long_name: 'the_first_model_in_the_db'
           short_name: 'model1'
-          num_ens_mems: '1'
+          num_ens_mems: 1
 
 mv_gefs_gdas_rtps_href_spring_2022:
     <<: *generic_database
+    fcst_is_ensemble: True
     models:
         - long_name: 'RRFS_GDAS_GF.SPP.SPPT'
           short_name: 'gdas'
@@ -29,6 +32,7 @@ mv_gefs_gdas_rtps_href_spring_2022:
 
 mv_rrfse_icpert_stoch:
     <<: *generic_database
+    fcst_is_ensemble: True
     models:
         - long_name: 'RRFSE_CONUS_ICperts_nostoch.rrfs_conuscompact_3km'
           short_name: 'nostoch'
@@ -36,3 +40,62 @@ mv_rrfse_icpert_stoch:
         - long_name: 'RRFSE_CONUS_ICperts_stoch.rrfs_conuscompact_3km'
           short_name: 'stoch'
           num_ens_mems: 10
+
+mv_hwt2024:
+    <<: *generic_database
+    valid_threshes:
+        ['gt0.0mm', 'ge0.508mm', 'ge2.54mm', 'ge6.350mm', 'ge12.7mm', 'ge25.4mm',
+         'ge20dBZ', 'ge30dBZ', 'ge40dBZ', 'ge50dBZ',
+         'ge20kft', 'ge30kft', 'ge40kft', 'ge50kft',
+         'ge258K', 'ge263K', 'ge268K', 'ge278K', 'ge283K', 'ge288K', 'ge293K', 'ge298K', 'ge303K',
+         'lt1609m', 'ge8045m', 'ge5400m', 'ge5880m',
+         'ge5mps', 'ge10mps', 'ge15mps', 'ge21mps']
+    fcst_is_ensemble: False
+    models:
+         - long_name: 'HRRR_mem000'
+           short_name: 'HRRR'
+           num_ens_mems: 1
+         - long_name: 'NSSL_MPAS_HN_mem000'
+           short_name: 'NSSL-MPAS-HN'
+           num_ens_mems: 1
+         - long_name: 'NSSL_MPAS_HT_mem000'
+           short_name: 'NSSL-MPAS-HT'
+           num_ens_mems: 1
+         - long_name: 'NSSL_MPAS_RT_mem000'
+           short_name: 'NSSL-MPAS-RT'
+           num_ens_mems: 1
+         - long_name: 'RRFS_mem000'
+           short_name: 'RRFS-A'
+           num_ens_mems: 1
+         - long_name: 'GSL_MPAS05_mem001'
+           short_name: 'GSL-MPAS-05-RT'
+           num_ens_mems: 1
+
+mv_rrfsv1_science_eval:
+    <<: *generic_database
+    valid_threshes:
+        ['gt0.0mm', 'ge0.508mm', 'ge2.54mm', 'ge6.350mm', 'ge12.7mm', 'ge25.4mm',
+         'ge20dBZ', 'ge30dBZ', 'ge40dBZ', 'ge50dBZ',
+         'ge20kft', 'ge30kft', 'ge40kft', 'ge50kft',
+         'ge258K', 'ge263K', 'ge268K', 'ge278K', 'ge283K', 'ge288K', 'ge293K', 'ge298K', 'ge303K',
+         #
+         'lt805m',  #  < 0.5 mi
+         'lt1609m', #  < 1 mi
+         'lt4828m', #  < 3 mi
+         'lt8045m', #  < 5 mi
+         'ge8045m', #  >= 5 mi
+         'lt16090', #  < 10 mi
+         #
+         'ge2.572mps',             # >= 5 kn
+         'ge2.572mps&&lt5.144mps', # >= 5 kn and < 10 kn
+         'ge5.144mps',             # >= 10 kn
+         'ge10.288mps',            # >= 20 kn
+         'ge15.433mps',            # >= 20 kn
+          ]
+    fcst_is_ensemble: False
+    vx_masks: ['CONUS', 'FULL', 'AZCA', 'EAST', 'EAST_ROCKIES', 'ECA', 'WCA', 'WEST']
+    models:
+         - long_name: 'RRFS_verification_mem000'
+           short_name: 'RRFS'
+           num_ens_mems: 1
+

--- a/DTC/metviewer_plotting/parm/auc_brier.xml
+++ b/DTC/metviewer_plotting/parm/auc_brier.xml
@@ -47,6 +47,12 @@
 {%- endfor %}
                 </set>
             </field>
+            <field equalize="true" name="vx_mask">
+{%- set ipf = ipf+1 %}
+                <set name="vx_mask_{{ipf}}">
+                    <val>{{vx_mask}}</val>
+                </set>
+            </field>
             <field equalize="true" name="fcst_lev">
 {%- set ipf = ipf+1 %}
                 <set name="fcst_lev_{{ipf}}">

--- a/DTC/metviewer_plotting/parm/bcrmse_bias_fbar_fbias_gss_obar_rmse.xml
+++ b/DTC/metviewer_plotting/parm/bcrmse_bias_fbar_fbias_gss_obar_rmse.xml
@@ -1,5 +1,15 @@
 {%- set do_indent = false -%}
 {%- set indent = "" -%}
+{#- Turn off plotting of base rate for now since it is not yet reliable. #}
+{%- set plot_base_rate = False -%}
+{#-
+{%- if (vx_metric_uc in ["FBIAS", "GSS"]) -%}
+  {%- set plot_base_rate = True -%}
+{%- endif -%}
+#}
+{%- set boot_replics = 10 -%}
+{%- set boot_rand_seed = 1 -%}
+{#- {%- set boot_rand_seed = '' -%} -#}
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <plot_spec>
     <connection>
@@ -22,10 +32,26 @@
         <dep>
             <dep1>
                 <fcst_var name="{{fcst_field_name_in_db}}">
+{%- if vx_metric_uc in ["FBAR_OBAR"] %}
+                    <stat>FBAR</stat>
+                    <stat>OBAR</stat>
+{%- else %}
                     <stat>{{vx_metric_mv}}</stat>
+{%- endif %}
                 </fcst_var>
             </dep1>
+{#- If plotting the base rate, use the second y-axis (the y2-axis) on 
+    the right-hand side of the plot.
+#}
+{%- if plot_base_rate %}
+            <dep2>
+                <fcst_var name="{{fcst_field_name_in_db}}">
+                    <stat>BASER</stat>
+                </fcst_var>
+            </dep2>
+{%- else %}
             <dep2/>
+{%- endif %}
         </dep>
         <series1>
             <field name="model">
@@ -37,12 +63,27 @@
     {{- indent ~ "<val>" ~ model ~ "_mean" ~ "</val>" -}}
   {%- endif -%}
   {%- for imem in range(1, num_ens_mems_by_model[imdl-1]+1) -%}
-    {{- indent ~ "<val>" ~ model ~ "_mem" ~ fmt%imem ~ "</val>" -}}
+    {%- if fcst_is_ensemble -%}
+      {{- indent ~ "<val>" ~ model ~ "_mem" ~ fmt%imem ~ "</val>" -}}
+    {%- else %}
+      {{- indent ~ "<val>" ~ model ~ "</val>" -}}
+    {%- endif %}
   {%- endfor -%}
 {%- endfor %}
             </field>
         </series1>
+{#- The following is specific to one METviewer database and will need to
+    be modified for others.
+#}
+{%- if plot_base_rate %}
+        <series2>
+            <field name="model">
+                <val>HRRR_mem000</val>
+            </field>
+        </series2>
+{%- else %}
         <series2/>
+{%- endif %}
 {%- set ipf = -1 %}
         <plot_fix>
             <field equalize="true" name="fcst_init_beg">
@@ -57,7 +98,7 @@
             <field equalize="true" name="vx_mask">
 {%- set ipf = ipf+1 %}
                 <set name="vx_mask_{{ipf}}">
-                    <val>CONUS</val>
+                    <val>{{vx_mask}}</val>
                 </set>
             </field>
             <field equalize="true" name="obtype">
@@ -72,7 +113,9 @@
                     <val>{{level_in_db}}</val>
                 </set>
             </field>
-{%- if (vx_metric_uc == "FBIAS") %}
+{#- Why is this included only when plotting the base rate but not otherwise?
+#}
+{%- if plot_base_rate %}
             <field equalize="true" name="fcst_thresh">
   {%- set ipf = ipf+1 %}
                 <set name="fcst_thresh_{{ipf}}">
@@ -108,75 +151,46 @@ to use summary statistics (although aggregate statistics is probably
 better), but for discontinuous fields, aggregate statistics should be
 used.
 
-However, it is not yet clear whether the above rule applies only to 
-FBIAS or to both BIAS and FBIAS (and possibly other statistics).  Thus,
-for now we apply the rule only to FBIAS.
+However, the safe approach is to always use aggregate statistics, so 
+that is what we do below.
+
+Note that the method used to calculate statistics (e.g. aggregate statistics
+vs. say summary statistics, which can be accomplished by using 
+
+  <plot_stat>median</plot_stat>
+
+instead of <agg_stat>...</agg_stat> below) affects not only the sizes of
+the confidence intervals but also the data points themselves (about which
+the confidence intervals are plotted).  To get the same curve regardless
+of whether plot_CIs is set to true or false, below we always calculate
+aggregate statistics.
 #}
-{%- if (vx_metric_uc == "BIAS") %}
-{#- Known discontinuous fields.  Use aggregate statistics in this case. #}
-  {%- if fcst_field_uc in ["APCP", "CAPE", "REFC", "RETOP"] %}
         <agg_stat>
             <agg_sl1l2>true</agg_sl1l2>
-            <boot_repl>10</boot_repl>
-            <boot_random_seed>1</boot_random_seed>
+            <boot_repl>{{boot_replics}}</boot_repl>
+            <boot_random_seed>{{boot_rand_seed}}</boot_random_seed>
             <boot_ci>perc</boot_ci>
             <eveq_dis>false</eveq_dis>
             <cache_agg_stat>false</cache_agg_stat>
             <circular_block_bootstrap>true</circular_block_bootstrap>
         </agg_stat>
-{#- Continuous fields for which we want to use aggregate statistics. #}
-  {%- elif fcst_field_uc in ["DPT", "HGT", "TMP", "VIS", "WIND"] %}
-        <agg_stat>
-            <agg_sl1l2>true</agg_sl1l2>
-            <boot_repl>10</boot_repl>
-            <boot_random_seed>1</boot_random_seed>
-            <boot_ci>perc</boot_ci>
-            <eveq_dis>false</eveq_dis>
-            <cache_agg_stat>false</cache_agg_stat>
-            <circular_block_bootstrap>true</circular_block_bootstrap>
-        </agg_stat>
-  {%- else %}
-        <plot_stat>median</plot_stat>
-  {%- endif %}
-{%- elif (vx_metric_uc == "FBIAS") %}
-{#- Known discontinuous fields.  Use aggregate statistics in this case. #}
-  {%- if fcst_field_uc in ["APCP", "CAPE", "REFC", "RETOP"] %}
-        <agg_stat>
-            <agg_ctc>true</agg_ctc>
-            <boot_repl>10</boot_repl>
-            <boot_random_seed>1</boot_random_seed>
-            <boot_ci>perc</boot_ci>
-            <eveq_dis>false</eveq_dis>
-            <cache_agg_stat>false</cache_agg_stat>
-            <circular_block_bootstrap>true</circular_block_bootstrap>
-        </agg_stat>
-{#- Continuous fields for which we want to use aggregate statistics. #}
-  {%- elif fcst_field_uc in ["VIS"] %}
-        <agg_stat>
-            <agg_ctc>true</agg_ctc>
-            <boot_repl>10</boot_repl>
-            <boot_random_seed>1</boot_random_seed>
-            <boot_ci>perc</boot_ci>
-            <eveq_dis>false</eveq_dis>
-            <cache_agg_stat>false</cache_agg_stat>
-            <circular_block_bootstrap>true</circular_block_bootstrap>
-        </agg_stat>
-{#- Known continuous fields.  Use summary statistics for these for now (may change later). #}
-  {%- elif fcst_field_uc in ["DPT", "HGT", "TMP"] %}
-        <plot_stat>median</plot_stat>
-{#- Default to summary statistics for unexpected fields. #}
-  {%- else %}
-        <plot_stat>median</plot_stat>
-  {%- endif %}
-{%- endif %}
         <tmpl>
             <data_file>plot_{{job_title}}.data</data_file>
             <plot_file>plot_{{job_title}}.png</plot_file>
             <r_file>plot_{{job_title}}.R</r_file>
             <title>{{plot_title}}</title>
             <x_label>Forecast Hour</x_label>
+{%- if vx_metric_uc in ["FBAR_OBAR"] %}
+            <y1_label>FBAR, OBAR</y1_label>
+{%- else %}
             <y1_label>{{vx_metric_uc}}</y1_label>
+{%- endif %}
+{#- If plotting the base rate on the y2-axis, add a label to that axis. #}
+{%- if plot_base_rate %}
+            <y2_label>Base Rate</y2_label>
+{%- else %}
             <y2_label/>
+{%- endif %}
             <caption>{{caption}}</caption>
             <job_title>{{job_title}}</job_title>
             <keep_revisions>false</keep_revisions>
@@ -272,7 +286,7 @@ it doesn't seem to make a difference in the final plot.
         <ci_alpha>0.05</ci_alpha>
         <eqbound_low>-0.001</eqbound_low>
         <eqbound_high>0.001</eqbound_high>
-        <!-- These appear in the MetViewer GUI under the column "Conf Interval".
+        <!-- These appear in the METviewer GUI under the column "Conf Interval".
              They specify the type of confidence intervals to plot ("none" for 
              no confidence intervals). -->
         <plot_ci>c(
@@ -280,34 +294,46 @@ it doesn't seem to make a difference in the final plot.
 {%- if do_indent -%}
   {%- set indent = " \\\n                   " -%}
 {%- endif -%}
-{%- for imdl in range(1, num_models_to_plot+1) -%}
+{#- #}
+{%- set plot_ci = "boot" -%}
+{%- if not plot_CIs -%}
   {%- set plot_ci = "none" -%}
+{%- endif -%}
+{#- #}
+{%- for imdl in range(1, num_models_to_plot+1) -%}
   {%- if incl_ens_means -%} "{{plot_ci}}", {%- endif -%}
   {%- for imem in range(1, num_ens_mems_by_model[imdl-1]) -%}
     "{{plot_ci}}",
   {%- endfor -%}
   "{{plot_ci}}"
   {%- if imdl != num_models_to_plot -%} ,{{indent}} {%- endif -%}
-{%- endfor -%})</plot_ci>
+{%- endfor -%}
+{%- if vx_metric_uc in ["FBAR_OBAR"] -%} ,"{{plot_ci}}" {%- endif -%}
+{#- Don't add confidence intervals to the base-rate data points. #}
+{%- if plot_base_rate -%} ,"none" {%- endif -%}
+        )</plot_ci>
 {#- #}
-        <!-- These appear in the MetViewer GUI under the column "Show Significant".
+        <!-- These appear in the METviewer GUI under the column "Show Significant".
              Not yet clear on what they do. -->
         <show_signif>c(
 {%- set indent = "" -%}
 {%- if do_indent -%}
   {%- set indent = " \\\n                       " -%}
 {%- endif -%}
+{%- set show_signif = "FALSE" -%}
 {%- for imdl in range(1, num_models_to_plot+1) -%}
-  {%- set show_signif = "FALSE" -%}
   {%- if incl_ens_means -%} {{show_signif}}, {%- endif -%}
   {%- for imem in range(1, num_ens_mems_by_model[imdl-1]) -%}
     {{show_signif}},
   {%- endfor -%}
   {{show_signif}}
   {%- if imdl != num_models_to_plot -%} ,{{indent}} {%- endif -%}
-{%- endfor -%})</show_signif>
+{%- endfor -%}
+{%- if vx_metric_uc in ["FBAR_OBAR"] -%} ,{{show_signif}} {%- endif -%}
+{%- if plot_base_rate -%} ,{{show_signif}} {%- endif -%}
+        )</show_signif>
 {#- #}
-        <!-- These appear in the MetViewer GUI under the column "Hide", although it
+        <!-- These appear in the METviewer GUI under the column "Hide", although it
              seems it is the opposite of this that is in the "Hide" column, i.e. if
              an element is set to "TRUE" here, it will show up as "FALSE" in the GUI.
              Not yet clear on what they do. -->
@@ -316,17 +342,20 @@ it doesn't seem to make a difference in the final plot.
 {%- if do_indent -%}
   {%- set indent = " \\\n                     " -%}
 {%- endif -%}
+{%- set plot_disp = "TRUE" -%}
 {%- for imdl in range(1, num_models_to_plot+1) -%}
-  {%- set plot_disp = "TRUE" -%}
   {%- if incl_ens_means -%} {{plot_disp}}, {%- endif -%}
   {%- for imem in range(1, num_ens_mems_by_model[imdl-1]) -%}
     {{plot_disp}},
   {%- endfor -%}
   {{plot_disp}}
   {%- if imdl != num_models_to_plot -%} ,{{indent}} {%- endif -%}
-{%- endfor -%})</plot_disp>
+{%- endfor -%}
+{%- if vx_metric_uc in ["FBAR_OBAR"] -%} ,{{plot_disp}} {%- endif -%}
+{%- if plot_base_rate -%} ,{{plot_disp}} {%- endif -%}
+        )</plot_disp>
 {#- #}
-        <!-- These appear in the MetViewer GUI under the column "Line Color".
+        <!-- These appear in the METviewer GUI under the column "Line Color".
              They control the line colors. -->
         <colors>c(
 {%- set indent = "" -%}
@@ -341,28 +370,38 @@ it doesn't seem to make a difference in the final plot.
   {%- endfor -%}
   "{{color}}"
   {%- if imdl != num_models_to_plot -%} ,{{indent}} {%- endif -%}
-{%- endfor -%})</colors>
+{%- endfor -%}
+{%- if vx_metric_uc in ["FBAR_OBAR"] -%} ,"{{color_obs}}" {%- endif -%}
+{#- Specify color for base-rate line. #}
+{%- set color_gray = "#808080" -%}
+{%- if plot_base_rate -%} ,"{{color_gray}}" {%- endif -%}
+        )</colors>
 {#- #}
-        <!-- These appear in the MetViewer GUI under the column "Point Symbol".
+        <!-- These appear in the METviewer GUI under the column "Point Symbol".
              They control the symbols used for the data points of each series. -->
         <pch>c(
 {%- set indent = "" -%}
 {%- if do_indent -%}
   {%- set indent = " \\\n               " -%}
 {%- endif -%}
+{%- set pch = 20 -%}
 {%- for imdl in range(1, num_models_to_plot+1) -%}
-  {%- set pch = 20 -%}
   {%- if incl_ens_means -%} {{pch}}, {%- endif -%}
   {%- for imem in range(1, num_ens_mems_by_model[imdl-1]) -%}
     {{pch}},
   {%- endfor -%}
   {{pch}}
   {%- if imdl != num_models_to_plot -%} ,{{indent}} {%- endif -%}
-{%- endfor -%})</pch>
+{%- endfor -%}
+{%- if vx_metric_uc in ["FBAR_OBAR"] -%} ,{{pch}} {%- endif -%}
+{%- if plot_base_rate -%} ,{{pch}} {%- endif -%}
+        )</pch>
 {#- #}
-        <!-- These appear in the MetViewer GUI under the column "Series Line Type".
-             "l" is for lines, and "b" is for "joined lines".
-             Not yet clear on what they do. -->
+        <!-- These appear in the METviewer GUI under the column "Series Line Type".
+             "l" is for "lines", and "b" is for "joined lines".  "l" or "lines" does
+             not include the plot symbol (specified by <pch>) at the data points,
+             while "b" or "joined lines" does.  There are other possibilities as well;
+             see the drop-down menu in the METviewer GUI for the full set of these. -->
         <type>c(
 {%- set indent = "" -%}
 {%- if do_indent -%}
@@ -381,9 +420,12 @@ it doesn't seem to make a difference in the final plot.
   {%- set line_type = line_types[is] -%}
   "{{line_type}}"
   {%- if imdl != num_models_to_plot -%} ,{{indent}} {%- endif -%}
-{%- endfor -%})</type>
+{%- endfor -%}
+{%- if vx_metric_uc in ["FBAR_OBAR"] -%} ,"{{line_type_obs}}" {%- endif -%}
+{%- if plot_base_rate -%} ,"{{line_types[0]}}" {%- endif -%}
+        )</type>
 {#- #}
-        <!-- These appear in the MetViewer GUI under the column "Line Type".
+        <!-- These appear in the METviewer GUI under the column "Line Type".
              1 is for "solid", 3 is for "dotted".
              They control the line types that join the data points. -->
         <lty>c(
@@ -391,17 +433,20 @@ it doesn't seem to make a difference in the final plot.
 {%- if do_indent -%}
   {%- set indent = " \\\n               " -%}
 {%- endif -%}
+{%- set lty = 1 -%}
 {%- for imdl in range(1, num_models_to_plot+1) -%}
-  {%- set lty = 1 -%}
   {%- if incl_ens_means -%} {{lty}}, {%- endif -%}
   {%- for imem in range(1, num_ens_mems_by_model[imdl-1]) -%}
     {{lty}},
   {%- endfor -%}
   {{lty}}
   {%- if imdl != num_models_to_plot -%} ,{{indent}} {%- endif -%}
-{%- endfor -%})</lty>
+{%- endfor -%}
+{%- if vx_metric_uc in ["FBAR_OBAR"] -%} ,{{lty}} {%- endif -%}
+{%- if plot_base_rate -%} ,{{lty}} {%- endif -%}
+        )</lty>
 {#- #}
-        <!-- These appear in the MetViewer GUI under the column "Line Width".
+        <!-- These appear in the METviewer GUI under the column "Line Width".
              They control the widths of the lines that join the data points. -->
         <lwd>c(
 {%- set indent = "" -%}
@@ -416,9 +461,12 @@ it doesn't seem to make a difference in the final plot.
   {%- endfor -%}
   {{line_width}}
   {%- if imdl != num_models_to_plot -%} ,{{indent}} {%- endif -%}
-{%- endfor -%})</lwd>
+{%- endfor -%}
+{%- if vx_metric_uc in ["FBAR_OBAR"] -%} ,{{line_width_obs}} {%- endif -%}
+{%- if plot_base_rate -%} ,{{line_widths[0]}} {%- endif -%}
+        )</lwd>
 {#- #}
-        <!-- These appear in the MetViewer GUI under the column "Connect Across".
+        <!-- These appear in the METviewer GUI under the column "Connect Across".
              0 is "no" and 1 is "yes".  
              Not yet clear on what they do. -->
         <con_series>c(
@@ -426,17 +474,20 @@ it doesn't seem to make a difference in the final plot.
 {%- if do_indent -%}
   {%- set indent = " \\\n                      " -%}
 {%- endif -%}
+{%- set cs = 1 -%}
 {%- for imdl in range(1, num_models_to_plot+1) -%}
-  {%- set cs = 1 -%}
   {%- if incl_ens_means -%} {{cs}}, {%- endif -%}
   {%- for imem in range(1, num_ens_mems_by_model[imdl-1]) -%}
     {{cs}},
   {%- endfor -%}
   {{cs}}
   {%- if imdl != num_models_to_plot -%} ,{{indent}} {%- endif -%}
-{%- endfor -%})</con_series>
+{%- endfor -%}
+{%- if vx_metric_uc in ["FBAR_OBAR"] -%} ,{{cs}} {%- endif -%}
+{%- if plot_base_rate -%} ,{{cs}} {%- endif -%}
+        )</con_series>
 {#- #}
-        <!-- These appear in the MetViewer GUI under the column "#" (number sign).
+        <!-- These appear in the METviewer GUI under the column "#" (number sign).
              They control the order of the series, although details aren't clear. -->
         <order_series>c(
 {%- set indent = "" -%}
@@ -450,10 +501,20 @@ it doesn't seem to make a difference in the final plot.
   {{- order_series[is.value:is.value+ns]|join(",") -}}
   {%- if imdl != num_models_to_plot -%} ,{{indent}} {%- endif -%}
   {%- set is.value = is.value + ns -%}
-{%- endfor -%})</order_series>
+{%- endfor -%}
+{%- set indx_last = order_series[-1] -%}
+{%- if vx_metric_uc in ["FBAR_OBAR"] -%}
+  {%- set indx_last = indx_last + 1 -%}
+  {{- "," ~ indx_last -}}
+{%- endif -%}
+{%- if plot_base_rate -%}
+  {%- set indx_last = indx_last + 1 -%}
+  {{- "," ~ indx_last -}}
+{%- endif -%}
+        )</order_series>
 {#- #}
         <plot_cmd/>
-        <!-- These appear in the MetViewer GUI under the column "Legend Text".
+        <!-- These appear in the METviewer GUI under the column "Legend Text".
              They specify the text that appears in the legend for each series. -->
         <legend>c(
 {%- set indent = "" -%}
@@ -464,19 +525,37 @@ it doesn't seem to make a difference in the final plot.
 {%- for imdl in range(1, num_models_to_plot+1) -%}
   {%- set model = model_names_short[imdl-1] -%}
   {%- if incl_ens_means -%} "{{model}}_mean", {%- endif -%}
-  {%- for imem in range(1, num_ens_mems_by_model[imdl-1]) -%}
-    "{{model}}{{fmt%imem}}",
-  {%- endfor -%}
-  {%- set imem = num_ens_mems_by_model[imdl-1] -%}
-  "{{model}}{{fmt%imem}}"
-  {%- if imdl != num_models_to_plot -%} ,{{indent}} {%- endif -%}
-{%- endfor -%})</legend>
+{#-
+Need to define (initialize) imem before entering if-statement.  Otherwise,
+jinja2 will fail.
+-#}
+  {%- set imem = 0 -%}
+  {%- if fcst_is_ensemble -%}
+    {%- for imem in range(1, num_ens_mems_by_model[imdl-1]) -%}
+      "{{model}}{{fmt%imem}}",
+    {%- endfor -%}
+    {%- set imem = num_ens_mems_by_model[imdl-1] -%}
+    "{{model}}{{fmt%imem}}"
+    {%- if imdl != num_models_to_plot -%} ,{{indent}} {%- endif -%}
+  {%- else -%}
+    "{{model}}"
+    {%- if imdl != num_models_to_plot -%} , {%- endif -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- if vx_metric_uc in ["FBAR_OBAR"] -%} ,"obs" {%- endif -%}
+{#- Specify the legend text for the base rate. #}
+{%- if plot_base_rate -%} ,"Base Rate" {%- endif -%}
+        )</legend>
 {#- #}
         <create_html>TRUE</create_html>
         <y1_lim>c()</y1_lim>
         <x1_lim>c()</x1_lim>
         <y1_bufr>0.04</y1_bufr>
+{%- if plot_base_rate %}
+        <y2_lim>c(0,0.25)</y2_lim>
+{%- else %}
         <y2_lim>c()</y2_lim>
+{%- endif %}
     </plot>
 </plot_spec>
 

--- a/DTC/metviewer_plotting/parm/rely_rhist.xml
+++ b/DTC/metviewer_plotting/parm/rely_rhist.xml
@@ -50,7 +50,7 @@
             <field equalize="true" name="vx_mask">
 {%- set ipf = ipf+1 %}
                 <set name="vx_mask_{{ipf}}">
-                    <val>CONUS</val>
+                    <val>{{vx_mask}}</val>
                 </set>
             </field>
             <field equalize="true" name="obtype">

--- a/DTC/metviewer_plotting/parm/ss.xml
+++ b/DTC/metviewer_plotting/parm/ss.xml
@@ -63,7 +63,7 @@ is available, so we use that.
             <field equalize="true" name="vx_mask">
 {%- set ipf = ipf+1 %}
                 <set name="vx_mask_{{ipf}}">
-                    <val>CONUS</val>
+                    <val>{{vx_mask}}</val>
                 </set>
             </field>
             <field equalize="true" name="obtype">

--- a/DTC/metviewer_plotting/valid_vx_plot_params.yaml
+++ b/DTC/metviewer_plotting/valid_vx_plot_params.yaml
@@ -1,30 +1,70 @@
 #
-# List of valid verification (vx) metric short names, the long name of
-# each, and whether each requires a threshold value for a given forecast
-# field.
+# List of valid verification (vx) metrics.  The first level of keys
+# are the short names of these metrics.  Under each short name are:
+#
+# 1) long_name:
+#    The long name of the metric.
+# 2) needs_thresh:
+#    Whether or not thresholds must be specified for the metric (with a
+#    different set of thresholds for each forecast field to be verified
+#    for the metric).
+# 3) CIs_allowed:
+#    Whether or not it makes sense and/or it is possible to calculate
+#    confidence intervals in METviewer for the metric.
 #
 valid_vx_metrics:
     auc:
         long_name: 'Area Under the Curve'
         needs_thresh: True
+        CIs_allowed: False
+    bcrmse:
+        long_name: 'Bias-Corrected RMSE'
+        needs_thresh: False
+        CIs_allowed: True
     bias:
         long_name: 'Bias'
         needs_thresh: False
+        CIs_allowed: True
     brier:
         long_name: 'Brier Score'
         needs_thresh: True
+        CIs_allowed: False
+    fbar:
+        long_name: 'Forecast Mean'
+        needs_thresh: False
+        CIs_allowed: True
+    fbar_obar:
+        long_name: 'Forecast and Obs Means'
+        needs_thresh: False
+        CIs_allowed: True
     fbias:
         long_name: 'Frequency Bias'
         needs_thresh: True
+        CIs_allowed: True
+    gss:
+        long_name: 'Gilbert Skill Score'
+        needs_thresh: True
+        CIs_allowed: True
+    obar:
+        long_name: 'Observations Mean'
+        needs_thresh: False
+        CIs_allowed: True
     rely:
         long_name: 'Reliability'
         needs_thresh: True
+        CIs_allowed: False
     rhist:
         long_name: 'Rank Histogram'
         needs_thresh: False
+        CIs_allowed: False
+    rmse:
+        long_name: 'Root Mean-Squared Error'
+        needs_thresh: False
+        CIs_allowed: True
     ss:
         long_name: 'Spread-Skill Ratio'
         needs_thresh: False
+        CIs_allowed: False
 #
 # List of valid forecast field short names, and, for each field:
 #
@@ -33,42 +73,66 @@ valid_vx_metrics:
 #   3) A list of valid levels.
 #
 valid_fcst_fields:
+    aotk:
+        long_name: 'Aerosol Optical Depth'
+        valid_units: ['']
+        valid_fcst_levels: ['L0']
+        is_cont: True
     apcp:
         long_name: 'Accumulated Precipitation'
         valid_units: ['mm']
         valid_fcst_levels: ['01h', '03h', '06h', '24h']
+        is_cont: False
     cape:
         long_name: 'Convenctive Available Potential Energy'
         valid_units: ['Jpkg']
         valid_fcst_levels: ['L0']
+        is_cont: False
     dpt:
         long_name: 'Dew Point'
         valid_units: ['K']
         valid_fcst_levels: ['2m', '500mb', '700mb', '850mb']
+        is_cont: True
     hgt:
         long_name: 'Height'
         valid_units: ['m']
         valid_fcst_levels: ['500mb']
+        is_cont: True
+    pm10:
+        long_name: 'PM10'
+        valid_units: ['ugpm3']
+        valid_fcst_levels: ['8m']
+        is_cont: True
+    pm25:
+        long_name: 'PM2.5'
+        valid_units: ['ugpm3']
+        valid_fcst_levels: ['8m']
+        is_cont: True
     refc:
         long_name: 'Composite Reflectivity'
         valid_units: ['dbz', 'dBZ']
         valid_fcst_levels: ['L0']
+        is_cont: False
     retop:
         long_name: 'Echo Top'
         valid_units: ['kft']
         valid_fcst_levels: ['L0']
+        is_cont: False
     tmp:
         long_name: 'Temperature'
         valid_units: ['K']
         valid_fcst_levels: ['2m', '500mb', '700mb', '850mb']
+        is_cont: True
     vis:
         long_name: 'Visibility'
         valid_units: ['m']
         valid_fcst_levels: ['L0']
+        is_cont: True
     wind:
         long_name: 'Wind'
         valid_units: ['mps']
         valid_fcst_levels: ['10m', '500mb', '700mb', '850mb']
+        is_cont: True
 #
 # Dictionary containing set of allowed levels (the keys) that can be
 # specified on the command line along with the corresponding strings
@@ -85,6 +149,7 @@ valid_fcst_levels_to_levels_in_db: {'01h': 'A1',
                                     '24h': 'A24',
                                     'L0': 'L0',
                                     '2m': 'Z2',
+                                    '8m': 'Z8',
                                     '10m': 'Z10', 
                                     '500mb': 'P500',
                                     '700mb': 'P700',


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
<!-- One or more paragraphs describing the problem, solution, and required changes. -->

* Add `aotk` (aerosol optical thickness), `pm10` (particulate matter > 10 um), and `pm25` (particulate matter greater than 2.5 um) as valid forecast fields to verify; add `8m` (8 meters) as a valid level (needed because `pm10` and `pm25` are at this level).

* Add a parameter (`CIs_allowed`) to each valid vx metric that specifies whether or not it is possible to plot confidence intervals (CIs) in METviewer for that metric.

* Add a parameter (`is_cont`) to each valid forecast field that specifies whether or not the field is continuous (if not, it is assumed to be discontinuous).  To pass this parameter to the single-plot script `make_single_mv_vx_plot.py`, add a command-line argument to the latter that specifies whether or not to try to generate confidence intervals (CIs) in the plot to be generated.

* Add `fbar`, `obar`, `fbar_obar`, `rmse`, `bcrmse`, and `gss` as valid vx metrics to plot.

* Add the flag `fcst_is_ensemble` as a property of METviewer databases in `mv_databases.yaml`.  This flag specifies whether or not the database contains an ensemble forecast (and if not, the forecast is assumed to be deterministic).

* Add the new METviewer database `mv_rrfsv1_science_eval`.  This is useful because it contains vx of `aotk`, `pm10`, and `pm25`.  Add an accompanying plotting configuration file (`multi_plot_config.mv_rrfsv1_science_eval.yaml`) that generates vx plots of `aotk`, `pm10`, and `pm25` and other fields in this database.

* Add the following new user-configurable parameters to the plot configuration file `multi_plot_config.default.yaml`:
  * `vx_mask`:
    The verification mask to use.  Any points outside this mask are not included when calculating vx metrics.
  * `plot_CIs_all_metrics`:
    Flag that determines whether to include confidence intervals (CIs) in the plots.  Note that this is a single flag that applies to all vx metrics to be plotted.  If this is set to True, then any metric for which CIs can be plotted in METviewer (as determined by the parameter `CIs_allowed` for each valid metric in `valid_vx_plot_params.yaml`) will have a plot that includes CIs.

* Modify the argument parser object in `make_multi_mv_vx_plots.py` in order to show default values of arguments when the help is invoked from the command line.

* Add a flag (`plot_base_rate`) to the jinja2 template `bcrmse_bias_fbar_fbias_gss_obar_rmse.xml` that determines whether or not the base rate is included in the plot; set this flag to `False` for now since the base rate calculation is not yet generalized to all databases.

* Always use bootstrapping for generating values and (if required) confidence intervals for the vx metrics `bcrmse`, `bias`, `fbar`, `fbias`, `gss`, `obar`, and `rmse`.  Note that the way these statistics are calculated affects both the data point values and the error bars around them.  (Use of bootstrapping will very likely have to be extended to the remaining valid statistics, i.e. `auc`, `brier`, `rely`, `rhist`, and `ss`.)

